### PR TITLE
feat(metadata-assertions): retrieve secondary metadata assertions from Events

### DIFF
--- a/src/db/pool.rs
+++ b/src/db/pool.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 
 pub(crate) async fn get_pool() -> Result<Pool<Postgres>, sqlx::Error> {
     let pool: Pool<Postgres> = PgPoolOptions::new()
-        .max_connections(5)
+        .max_connections(50)
         // Allow for long transactions for bulk ingestion
         .idle_timeout(Duration::from_secs(60 * 60))
         .connect("postgres://metabeak:metabeak@localhost/metabeak")

--- a/src/db/source.rs
+++ b/src/db/source.rs
@@ -5,7 +5,12 @@
 pub(crate) enum MetadataSourceId {
     Unknown = 0,
     Test = 1,
+
+    /// Direct from Crossref
     Crossref = 2,
+
+    /// Retrieved from the relevant RA by content negotiation. This might be Crossref, DataCite or others.
+    ContentNegotiation = 3,
 }
 
 impl MetadataSourceId {
@@ -13,6 +18,7 @@ impl MetadataSourceId {
         match value {
             "crossref" => MetadataSourceId::Crossref,
             "test" => MetadataSourceId::Test,
+            "content-negotiation" => MetadataSourceId::ContentNegotiation,
             _ => MetadataSourceId::Unknown,
         }
     }
@@ -21,6 +27,7 @@ impl MetadataSourceId {
         match value {
             2 => MetadataSourceId::Crossref,
             1 => MetadataSourceId::Test,
+            3 => MetadataSourceId::ContentNegotiation,
             _ => MetadataSourceId::Unknown,
         }
     }
@@ -28,6 +35,7 @@ impl MetadataSourceId {
     pub(crate) fn to_str_value(self) -> String {
         String::from(match self {
             MetadataSourceId::Crossref => "crossref",
+            MetadataSourceId::ContentNegotiation => "content-negotiation",
             MetadataSourceId::Test => "test",
             _ => "UNKNOWN",
         })
@@ -40,7 +48,7 @@ mod metadata_source_tests {
 
     #[test]
     fn roundtrip_metadatasource() {
-        let inputs = ["crossref", "test"];
+        let inputs = ["crossref", "test", "content-negotiation"];
         for input in inputs.iter() {
             let from_str = MetadataSourceId::from_str_value(input);
             let as_str = from_str.to_str_value();

--- a/src/metadata_assertion/crossref/metadata_agent.rs
+++ b/src/metadata_assertion/crossref/metadata_agent.rs
@@ -3,14 +3,17 @@
 use std::sync::mpsc::{self, Receiver, Sender};
 
 use scholarly_identifiers::identifiers::Identifier;
-use sqlx::{Pool, Postgres, Transaction};
+use sqlx::{Pool, Postgres};
 
 use time::{Duration, OffsetDateTime};
 
 use crate::db::agents::get_checkpoint;
 use crate::db::agents::set_checkpoint;
-use crate::metadata_assertion::crossref::metadata::get_index_date;
-use crate::metadata_assertion::crossref::works_api_client::harvest_to_channel;
+use crate::db::metadata::MetadataAssertionReason;
+use crate::metadata_assertion::crossref::works_api_client::harvest_deposited_date_to_chan;
+use crate::metadata_assertion::crossref::{
+    metadata::get_index_date, works_api_client::harvest_precise_index_date,
+};
 use crate::metadata_assertion::service::assert_metadata;
 
 /// Date value for checkpointing the harvest.
@@ -18,7 +21,7 @@ const CROSSREF_NB: &str = "crossref-not-before";
 
 /// Retrieve all new Crossref data since the last run.
 /// The date used for checkpointing is the latest indexed date reported by the Crossref API, not the local datetime.
-pub(crate) async fn pump_metadata(pool: &Pool<Postgres>) -> anyhow::Result<()> {
+pub(crate) async fn poll_newly_indexed_data(pool: &Pool<Postgres>) -> anyhow::Result<()> {
     let mut tx = pool.begin().await?;
     // Start from most recent run, now.
     // Add 1 hour margin for jitter. This results in duplicate fetches but they are de-duplicated in the database.
@@ -28,9 +31,28 @@ pub(crate) async fn pump_metadata(pool: &Pool<Postgres>) -> anyhow::Result<()> {
         .saturating_sub(Duration::HOUR);
     let after = saturating_sub;
 
-    let new_after = harvest(&after, &mut tx, pool).await?;
+    // Get only assertions indexed after the date.
+    let new_after = harvest_recently_indexed(&after, pool).await?;
 
     set_checkpoint(CROSSREF_NB, new_after, &mut tx).await?;
+
+    tx.commit().await?;
+
+    Ok(())
+}
+
+/// Retrieve all Crossref data since the given point in time, and make secondary
+/// assertions (i.e don't trigger Event creation).
+pub(crate) async fn fetch_secondary_metadata_after(
+    pool: &Pool<Postgres>,
+    after: OffsetDateTime,
+) -> anyhow::Result<()> {
+    let tx = pool.begin().await?;
+
+    // Get all assertions that cover the start of that day.
+    // We might get a few extra, but there's no harm in that.
+    // By using [precise_date] = false we don't make the Crossref API server sort its results, which is more efficient.
+    harvest_secondary(&after, pool).await?;
 
     tx.commit().await?;
 
@@ -57,9 +79,8 @@ pub(crate) fn get_identifier_and_json(
 
 /// Harvest data until the given date, returning the index date of the most recent.
 /// If none were retrieved, the `after` date is returned, so it can be attepmted again next time.
-pub(crate) async fn harvest<'a>(
+pub(crate) async fn harvest_recently_indexed<'a>(
     after: &OffsetDateTime,
-    tx: &mut Transaction<'a, Postgres>,
     pool: &Pool<Postgres>,
 ) -> anyhow::Result<OffsetDateTime> {
     let (send_metadata_docs, receive_metadata_docs): (
@@ -68,7 +89,9 @@ pub(crate) async fn harvest<'a>(
     ) = mpsc::channel();
     let after_a = *after;
     let c =
-        tokio::task::spawn(async move { harvest_to_channel(send_metadata_docs, after_a).await });
+        tokio::task::spawn(
+            async move { harvest_precise_index_date(send_metadata_docs, after_a).await },
+        );
 
     let mut latest_date = *after;
 
@@ -81,14 +104,60 @@ pub(crate) async fn harvest<'a>(
             if let Some((identifier, json)) = get_identifier_and_json(item) {
                 count += 1;
                 if (count % 1000) == 0 {
-                    log::debug!("Done {} items.", count);
+                    log::info!("Harvested {} items.", count);
                 }
 
                 assert_metadata(
                     &identifier,
                     &json,
                     crate::db::source::MetadataSourceId::Crossref,
-                    tx,
+                    MetadataAssertionReason::Primary,
+                    pool,
+                )
+                .await?;
+            }
+        }
+    }
+    log::info!("Stop harvest, retrieved {}, latest {}", count, latest_date);
+
+    c.await?.unwrap();
+    Ok(latest_date)
+}
+
+/// Harvest data until the given date, returning the index date of the most recent.
+/// If none were retrieved, the `after` date is returned, so it can be attepmted again next time.
+pub(crate) async fn harvest_secondary<'a>(
+    after: &OffsetDateTime,
+    pool: &Pool<Postgres>,
+) -> anyhow::Result<OffsetDateTime> {
+    let (send_metadata_docs, receive_metadata_docs): (
+        Sender<serde_json::Value>,
+        Receiver<serde_json::Value>,
+    ) = mpsc::channel();
+    let after_a = *after;
+    let c = tokio::task::spawn(async move {
+        harvest_deposited_date_to_chan(send_metadata_docs, after_a).await
+    });
+
+    let mut latest_date = *after;
+
+    log::info!("Start harvest after {}", after);
+    let mut count = 0;
+    for item in receive_metadata_docs {
+        if let Some(indexed) = get_index_date(&item) {
+            latest_date = indexed.max(latest_date);
+
+            if let Some((identifier, json)) = get_identifier_and_json(item) {
+                count += 1;
+                if (count % 1000) == 0 {
+                    log::info!("Harvested {} items.", count);
+                }
+
+                assert_metadata(
+                    &identifier,
+                    &json,
+                    crate::db::source::MetadataSourceId::Crossref,
+                    MetadataAssertionReason::Secondary,
                     pool,
                 )
                 .await?;

--- a/src/metadata_assertion/crossref/works_api_client.rs
+++ b/src/metadata_assertion/crossref/works_api_client.rs
@@ -35,15 +35,16 @@ async fn request_url(url: &str) -> Result<CrossrefResponse> {
 }
 
 /// Fetch historical data until the given [`not_before`] date.
-/// Due to lack of secondary sort, it's sensible to add extra padding.
-pub(crate) async fn fetch(
+/// Request sorted results, so we can stop paging when we hit the date.
+/// Due to lack of secondary sort beyond date, it's sensible to add extra padding.
+pub(crate) async fn fetch_from_indexed(
     rows: u32,
     cursor: &str,
-    from_index_date: &str,
+    from_date: &str,
 ) -> Result<(Vec<serde_json::Value>, String)> {
     let url = format!(
         "{}?filter=from-index-date:{}&sort=indexed&order=desc&rows={}&cursor={}",
-        BASE, from_index_date, rows, cursor
+        BASE, from_date, rows, cursor
     );
 
     let request = || request_url(&url);
@@ -51,8 +52,8 @@ pub(crate) async fn fetch(
 
     // On first page log how many results might be present.
     if cursor == "*" {
-        log::debug!(
-            "Fetching results, total possible {} ",
+        log::info!(
+            "Fetching results since index date, total possible {} ",
             response.message.total_results
         );
     }
@@ -60,7 +61,40 @@ pub(crate) async fn fetch(
     Ok((response.message.items, response.message.next_cursor))
 }
 
-pub(crate) async fn harvest_to_channel(
+/// Fetch documents deposited with Crossref since the date.
+/// The use case for this query is for larger time ranges where stopping iteration at the exact time-of-day isn't necessary.
+/// As we we expect to consume the entire result set, sorting isn't requested.
+pub(crate) async fn fetch_from_deposited(
+    rows: u32,
+    cursor: &str,
+    from_date: &str,
+) -> Result<(Vec<serde_json::Value>, String)> {
+    let url = format!(
+        "{}?filter=from-deposit-date:{}&rows={}&cursor={}",
+        BASE, from_date, rows, cursor
+    );
+
+    let request = || request_url(&url);
+    let response = request.retry(ExponentialBuilder::default()).await?;
+
+    // On first page log how many results might be present.
+    if cursor == "*" {
+        log::info!(
+            "Fetching results since deposit date, total possible {} ",
+            response.message.total_results
+        );
+    }
+
+    Ok((response.message.items, response.message.next_cursor))
+}
+
+/// Harvest metadata indexed with Crossref since date-time to channel.
+/// Stop at the precise date-time, plus some padding.
+///
+/// This is designed for doing continual live queries to the API. It doesn't
+/// consume the entire result set, only those works that were indexed since the
+/// given date-time.
+pub(crate) async fn harvest_precise_index_date(
     chan: Sender<serde_json::Value>,
     after: OffsetDateTime,
 ) -> Result<()> {
@@ -72,17 +106,20 @@ pub(crate) async fn harvest_to_channel(
 
     let ymd_format = format_description::parse("[year]-[month]-[day]").unwrap();
 
-    // The API only deals in time intervals of one day, so we can't request the specific cut-off time. Instead we need to truncate it to the day boundary.
-    // Choose the start of the day before the requested cut-off. This means we're not asking the API to sort the entire data set.
-    // It should be sufficient to use the start of the current day, but adding an extra day avoids a potential boundary condition.
-    // We won't retrieve that much data, as we finish pagination when we hit the not_before date.
+    // The API only deals in time intervals of one day, so we can't request the
+    // specific cut-off time. Instead we need to truncate it to the day
+    // boundary. Choose the start of the day before the requested cut-off. This
+    // means we're not asking the API to sort the entire data set. It should be
+    // sufficient to use the start of the current day, but adding an extra day
+    // avoids a potential boundary condition. We won't retrieve that much data,
+    // as we finish pagination when we hit the not_before date.
     let from_index_date = after
         .saturating_sub(Duration::DAY)
         .format(&ymd_format)
         .unwrap();
 
     while again {
-        let result = fetch(rows, &cursor, &from_index_date).await;
+        let result = fetch_from_indexed(rows, &cursor, &from_index_date).await;
 
         match result {
             Ok((items, new_cursor)) => {
@@ -106,6 +143,7 @@ pub(crate) async fn harvest_to_channel(
                     .collect();
 
                 // Stop when there are no results after the not_before date. Results are ordered by the index date, so it's safe to stop here.
+                // Only stop at the precise date when flag is set. Otherwise rely on the API to send whatever fits the query.
                 if wanted_items.is_empty() {
                     again = false;
                 }
@@ -117,6 +155,52 @@ pub(crate) async fn harvest_to_channel(
                 );
 
                 for item in wanted_items {
+                    chan.send(item).unwrap();
+                }
+                cursor = new_cursor;
+            }
+            Err(e) => {
+                log::error!("Error! {:?}", e);
+                again = false;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Harvest metadata deposited with Crossref since date to channel.
+///
+/// This is designed for large date ranges, so consumes the entire result rather than stopping at a precise date-time.
+pub(crate) async fn harvest_deposited_date_to_chan(
+    chan: Sender<serde_json::Value>,
+    after: OffsetDateTime,
+) -> Result<()> {
+    log::debug!("Harvest to channel");
+
+    let rows = 1000;
+    let mut cursor = String::from("*");
+    let mut again = true;
+
+    let ymd_format = format_description::parse("[year]-[month]-[day]").unwrap();
+
+    let from_index_date = after.format(&ymd_format).unwrap();
+
+    while again {
+        let result = fetch_from_deposited(rows, &cursor, &from_index_date).await;
+
+        match result {
+            Ok((items, new_cursor)) => {
+                let num_items = items.len();
+
+                // Stop when there are zero results, means we reached the end of the result set.
+                if num_items == 0 {
+                    again = false;
+                }
+
+                log::debug!("Page of {}.", num_items,);
+
+                for item in items {
                     chan.send(item).unwrap();
                 }
                 cursor = new_cursor;

--- a/src/metadata_assertion/mod.rs
+++ b/src/metadata_assertion/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod crossref;
+pub(crate) mod retrieve;
 pub(crate) mod service;

--- a/src/metadata_assertion/retrieve/doi.rs
+++ b/src/metadata_assertion/retrieve/doi.rs
@@ -1,0 +1,91 @@
+use anyhow::Result;
+use backon::ConstantBuilder;
+use backon::Retryable;
+use scholarly_identifiers::identifiers::Identifier;
+use serde_json::Value;
+use std::time::Duration;
+use tokio::time::sleep;
+
+use crate::db::metadata::MetadataAssertionReason;
+use crate::db::source::MetadataSourceId;
+use crate::metadata_assertion::service::assert_metadata;
+
+/// Attempt to fetch and store a metadata assertion for a DOI.
+pub(crate) async fn try_collect_metadata_assertion(
+    identifier: &scholarly_identifiers::identifiers::Identifier,
+    pool: &sqlx::Pool<sqlx::Postgres>,
+) -> Result<()> {
+    if let Identifier::Doi {
+        prefix: _,
+        suffix: _,
+    } = identifier
+    {
+        log::debug!("Try collect metadata for: {:?}", identifier);
+        if let Some(url) = identifier.to_uri() {
+            let request = || request_url(&url);
+            match request
+                .retry(
+                    ConstantBuilder::default()
+                        .with_max_times(2)
+                        .with_delay(Duration::from_millis(500)),
+                )
+                .await
+            {
+                Ok(json) => {
+                    assert_metadata(
+                        identifier,
+                        &json.to_string(),
+                        MetadataSourceId::ContentNegotiation,
+                        MetadataAssertionReason::Secondary,
+                        pool,
+                    )
+                    .await?;
+                    Ok(())
+                }
+                Err(err) => {
+                    log::error!(
+                        "Error retrieving content negotiation for DOI: {:?}: {:?}",
+                        identifier,
+                        err
+                    );
+                    Ok(())
+                }
+            }
+        } else {
+            // If it's not possible to build a URI for a DOI, that's an internal problem. Log and move on.
+            // The metadata won't be asserted.
+            log::error!("Failed to build URI for DOI {:?}", identifier);
+            Ok(())
+        }
+    } else {
+        Ok(())
+    }
+}
+
+async fn request_url(url: &str) -> Result<Value> {
+    log::debug!("Try {}", url);
+
+    let client = reqwest::Client::new();
+    let response = client
+        .get(url)
+        .header("Accept", "application/vnd.citationstyles.csl+json")
+        .send()
+        .await?;
+
+    if response.status() != 200 {
+        log::info!("Got {} from {:?}", response.status(), response.headers());
+    }
+
+    // Special case for slow down.
+    if response.status() == 429 {
+        log::error!("Slowing down!");
+        sleep(Duration::from_secs(10)).await;
+    }
+
+    let text = response.text().await?;
+
+    // Parse the response to ensure we got back valid JSON.
+    let json = serde_json::from_str::<Value>(&text)?;
+
+    Ok(json)
+}

--- a/src/metadata_assertion/retrieve/mod.rs
+++ b/src/metadata_assertion/retrieve/mod.rs
@@ -1,0 +1,25 @@
+use scholarly_identifiers::identifiers::Identifier;
+use sqlx::{Pool, Postgres};
+
+use crate::db;
+
+pub(crate) mod doi;
+pub(crate) mod ror;
+
+/// Attempt to ensure an entity has a metadata assertion.
+pub(crate) async fn ensure_metadata_assertion(
+    identifier: &Identifier,
+    entity_id: i64,
+    pool: &Pool<Postgres>,
+) {
+    // Check for presence of any metadata assertion on that entity.
+    // The source and date don't matter, as we'll take the latest.
+    if !db::metadata::has_metadata_assertion(entity_id, pool).await {
+        // Each function will only assert metadata if it recognises the type. No need for a switch here, as it would be extraneous.
+        if let Err(err) = doi::try_collect_metadata_assertion(identifier, pool).await {
+            log::error!("Failed to collect metadata for {:?}, {:?}", identifier, err);
+        }
+    } else {
+        log::debug!("Already got metadata for {:?}, {}", identifier, entity_id);
+    }
+}

--- a/src/metadata_assertion/retrieve/ror.rs
+++ b/src/metadata_assertion/retrieve/ror.rs
@@ -1,0 +1,7 @@
+pub(crate) async fn retrieve_metadata_assertion(
+    identifier: &scholarly_identifiers::identifiers::Identifier,
+    entity_id: i64,
+    pool: &sqlx::Pool<sqlx::Postgres>,
+) {
+    todo!()
+}


### PR DESCRIPTION
trigger retrieval of metadata for all DOIs generated in Events

add concept of secondary metadata assertion
implement fetching for DOIs via content negotiation, placeholder for ROR IDs also add fetch-crossref-secondary to backfill